### PR TITLE
Rename of the response property phoneNumChanged

### DIFF
--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -153,9 +153,9 @@ components:
     CheckNumRecyclingInfo:
       type: object
       required:
-        - phoneNumChanged
+        - phoneNumberRecycled
       properties:
-        phoneNumChanged:
+        phoneNumberRecycled:
           type: boolean
           description: |
             Set to true (Boolean, not string) when there has been a change in the subscriber associated with the specific phone number after “specifiedDate”.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:
Based on the discussion for #26 and #36, The PR proposes to rename `phoneNumChanged` in the API response.

#### Which issue(s) this PR fixes:

Fixes #26 and #36.

#### Special notes for reviewers:
Due to time pressure, this PR will need to be merged before the next KYC meeting.