### PR TITLE
Public Release r1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The API definition(s) are based on
 
 **number-recycling v0.1.1 is the second public release version of the Number-Recycling API.**
 
-- number-recycling v0.1.0 API definition **with inline documentation**:
+- number-recycling v0.1.1 API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)
   - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberRecycling/blob/r1.3/code/API_definitions/number-recycling.yaml)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The API definition(s) are based on
 * N/A
 
 ### Fixed
-* Fix the Missing description field in 422 Missing IdentifierTypo in https://github.com/camaraproject/NumberRecycling/pull/41
+* Fix the Missing description field in 422 Missing Identifier in https://github.com/camaraproject/NumberRecycling/pull/44
 
 ### Removed
 * N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+- [r1.3](#r13)
 - [r1.2](#r12)
 - [r1.1](#r11)
 
@@ -13,6 +14,43 @@ The below sections record the changes for each API version in each release as fo
 * for the first release-candidate, all changes since the last public release
 * for subsequent release-candidate(s), only the delta to the previous release-candidate
 * for a public release, the consolidated changes since the previous public release
+
+# r1.3
+
+## Release Notes
+
+This release contains the definition and documentation of
+* number-recycling v0.1.0
+
+The API definition(s) are based on
+* Commonalities v0.5.0
+* Identity and Consent Management v0.3.0
+
+## number-recycling v0.1.0
+
+**number-recycling v0.1.0 is the first public release version of the Number-Recycling API.**
+
+- number-recycling v0.1.0 API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/NumberRecycling/blob/r1.3/code/API_definitions/number-recycling.yaml)
+
+### Added
+* N/A
+
+### Changed
+* N/A
+
+### Fixed
+* Fix the Missing description field in 422 Missing IdentifierTypo in https://github.com/camaraproject/NumberRecycling/pull/41
+
+### Removed
+* N/A
+
+## New Contributors
+* N/A
+
+**Full Changelog**: https://github.com/camaraproject/NumberRecycling/commits/r1.3
 
 # r1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,15 @@ The below sections record the changes for each API version in each release as fo
 ## Release Notes
 
 This release contains the definition and documentation of
-* number-recycling v0.1.0
+* number-recycling v0.1.1
 
 The API definition(s) are based on
 * Commonalities v0.5.0
 * Identity and Consent Management v0.3.0
 
-## number-recycling v0.1.0
+## number-recycling v0.1.1
 
-**number-recycling v0.1.0 is the first public release version of the Number-Recycling API.**
+**number-recycling v0.1.1 is the second public release version of the Number-Recycling API.**
 
 - number-recycling v0.1.0 API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Sandbox API Repository to describe, develop, document, and test the NumberRecycl
 
 * Note: Please be aware that the project will have updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. For best results, use the latest available release.
 
-* **The first public release of CAMARA Number Recycling is [r1.2](https://github.com/camaraproject/NumberRecycling/releases/tag/r1.2)**. The Release Tag is [r1.2](https://github.com/camaraproject/NumberRecycling/releases/tag/r1.2).
+* **The public release of CAMARA Number Recycling is [r1.3](https://github.com/camaraproject/NumberRecycling/releases/tag/r1.3)**. The Release Tag is [r1.3](https://github.com/camaraproject/NumberRecycling/releases/tag/r1.3).
+<br>This is a public release. Generated as a Patch release of [r1.2]
   - Contains the following API definitions **with inline documentation**:
-    - [YAML spec file](https://github.com/camaraproject/NumberRecycling/blob/r1.2/code/API_definitions/number-recycling.yaml) | [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.2/code/API_definitions/number-recycling.yaml&nocors) | [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.2/code/API_definitions/number-recycling.yaml&nocors)
+    - [YAML spec file](https://github.com/camaraproject/NumberRecycling/blob/r1.3/code/API_definitions/number-recycling.yaml) | [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors) | [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.3/code/API_definitions/number-recycling.yaml&nocors)
 
 ## Contributing
 * Meetings of KnowYourCustomer Sub Project are held virtually 

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -63,7 +63,7 @@ info:
     - If the subject cannot be identified from the access token and the optional `phoneNumber` field is not included in the request, then the server will return an error with the `422 MISSING_IDENTIFIER` error code.
     - If the subject can be identified from the access token and the optional `phoneNumber` field is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same phone number is identified by these two methods, as the server is unable to make this comparison.
 
-  version: 0.1.0
+  version: 0.1.1
   x-camara-commonalities: 0.5
 
   license:

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -338,6 +338,7 @@ components:
                 code: UNNECESSARY_IDENTIFIER
                 message: The phone number is already identified by the access token
             Missing Identifier:
+              description: An identifier is not included in the request and the phone number identification cannot be derived from the 3-legged access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER

--- a/code/Test_definitions/number-recycling.feature
+++ b/code/Test_definitions/number-recycling.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Number Recycling API, v0.1.0 - Operation number-recycling
+Feature: CAMARA Number Recycling API, v0.1.1 - Operation number-recycling
   # Environment variables:
   # * api_root: API root of the server URL
   #

--- a/documentation/API_documentation/number-recycling-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/number-recycling-API-Readiness-Checklist.md
@@ -1,6 +1,6 @@
 # API Readiness Checklist
 
-Checklist for number-recycling v0.1.0 in r1.2
+Checklist for number-recycling v0.1.1 in r1.3
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:
The description field for 422 Missing Identifier in YAML file is missing.
Generates a Patch release


#### Which issue(s) this PR fixes:

Fixes #43 

#### Special notes for reviewers:

- Fix description field for 422 Missing Identifier in YAML (no functional change)
- Updated Test Definitions
- Updated API readiness Checklist
- Updated ChangeLog
- Updated Readme


#### Changelog input

```
Public release r1.3 for Number Recycling API

```

#### Additional documentation 

This section can be blank.



```
docs

```
