### PR TITLE
Reset versions in API and test definitions back to wip after r2.1

### DIFF
--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -68,7 +68,7 @@ info:
     Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
-  version: 0.2.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 
   license:
@@ -78,7 +78,7 @@ externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/NumberRecycling
 servers:
-  - url: '{apiRoot}/number-recycling/v0.2rc1'
+  - url: '{apiRoot}/number-recycling/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/number-recycling.feature
+++ b/code/Test_definitions/number-recycling.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Number Recycling API, v0.2.0-rc.1 - Operation checkNumberRecycling
+Feature: CAMARA Number Recycling API, vwip - Operation checkNumberRecycling
   # Environment variables:
   # * api_root: API root of the server URL
   #
@@ -10,7 +10,7 @@ Feature: CAMARA Number Recycling API, v0.2.0-rc.1 - Operation checkNumberRecycli
 
   Background: Common checkNumberRecycling setup
       Given an environment at "apiRoot"
-      And the resource "/number-recycling/v0.2rc1/check"
+      And the resource "/number-recycling/vwip/check"
       And the header "Content-Type" is set to "application/json"
       And the header "Authorization" is set to a valid access token
       And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* repository management

#### What this PR does / why we need it:
Setting the version in API and test definitions back to wip after r2.1 to clearly indicate that any change done between r2.1 and r2.2 does not belong to neither of the releases.

That will allow to address open issues with PRs without taking care of the version field.

#### Which issue(s) this PR fixes:
Fixes # none (repository management)

#### Special notes for reviewers:
I have created this PR with reference to [a similar PR in QoD SP](https://github.com/camaraproject/QualityOnDemand/pull/421).
