### PR TITLE
Missing summary for operation POST /check

### DIFF
--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -91,6 +91,7 @@ paths:
             - number-recycling:check
       tags:
         - Check Number Recycling
+      summary: Check whether the subscriber of the phone number has changed.
       description: Check whether the subscriber of the phone number has changed.
       operationId: checkNumberRecycling
       parameters:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
The operation has no summary, while the API Design Guide requires a summary for every operation.
Thus, a short summary is added.

#### Which issue(s) this PR fixes:

Fixes #62 

#### Special notes for reviewers:
Detected late in the M3 pre-release review, non critical for the release candidate version, can be added until/for M4 release.
See #https://github.com/camaraproject/NumberRecycling/pull/53#issuecomment-3109311180