### PR TITLE
Response schema not aligned with Commonalities guidelines

### DIFF
--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -106,7 +106,14 @@ paths:
         required: true
       responses:
         '200':
-          $ref: '#/components/responses/Generic200'
+          description: OK
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckNumRecyclingInfo"
         '400':
           $ref: '#/components/responses/Generic400'
         '401':


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:
The 200 response schema is not aligned with [Commonalities Guidelines](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#576-responses).
We are using a response object when we should state the schema explicitely.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #77 

#### Special notes for reviewers:
This PR is for next release.

#### Changelog input

```
 release-note

```

#### Additional documentation 
None