### PR TITLE
Alignment with whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 Sandbox API Repository to describe, develop, document, and test the NumberRecycling API within the [Know Your Customer (KYC)](https://lf-camaraproject.atlassian.net/wiki/x/I4DGB) Sub Project.
 
 * API Repository [wiki page](https://lf-camaraproject.atlassian.net/wiki/x/ggCaBQ)
+* CAMARA Resoureces [whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf)
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Sandbox API Repository to describe, develop, document, and test the NumberRecycling API within the [Know Your Customer (KYC)](https://lf-camaraproject.atlassian.net/wiki/x/I4DGB) Sub Project.
 
 * API Repository [wiki page](https://lf-camaraproject.atlassian.net/wiki/x/ggCaBQ)
-* CAMARA Resoureces [whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf)
+* CAMARA Resources [whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf)
 
 ## Scope
 

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -23,6 +23,7 @@ info:
 
     Note:
     * When API receives a request with specified date on which a user signed a contract with MNO, the API respond sets to 'false'(e.g., 2023-10-09 in the Scenario 1 of the figure above).
+    * This Scenario 1 corresponds to the Line 0601 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences" (https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
 
       * Scenario 2
         * Pre-conditions
@@ -40,7 +41,7 @@ info:
     <img width="4000" alt="Number_Recycling_scenario_2" src="https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.1/documentation/API_documentation/assets/Number_Recycling_scenario_2.png">
 
     Note:
-    * When the API receives a request with specified date during which there is no contract with MNO for the phone number, the API respond sets to 'true'(e.g., the period between 2024-02-25 and 2024-09-20 in the Scenario 2 of the figure above).
+    * This Scenario 2 corresponds to the Line 0607 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences" (https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
 
     ##How to choose specifiedDate by ASP (API consumer)
     ASP should choose a date when the ASP established a trusted association between the user and the phone number, for example onboarding, phone number verification, or another validated point in the ASP's own trust process. A previous Number Recycling check that returned `false` may be used as an operational reference date, if this is consistent with the ASP's own trust model.

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -41,7 +41,7 @@ info:
     <img width="4000" alt="Number_Recycling_scenario_2" src="https://raw.githubusercontent.com/camaraproject/NumberRecycling/r1.1/documentation/API_documentation/assets/Number_Recycling_scenario_2.png">
 
     Note:
-    * This Scenario 2 corresponds to the Line 0607 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences" (https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
+    * This Scenario 2 corresponds to the [Line 0607 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
 
     ##How to choose specifiedDate by ASP (API consumer)
     ASP should choose a date when the ASP established a trusted association between the user and the phone number, for example onboarding, phone number verification, or another validated point in the ASP's own trust process. A previous Number Recycling check that returned `false` may be used as an operational reference date, if this is consistent with the ASP's own trust model.

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -23,7 +23,7 @@ info:
 
     Note:
     * When API receives a request with specified date on which a user signed a contract with MNO, the API respond sets to 'false'(e.g., 2023-10-09 in the Scenario 1 of the figure above).
-    * This Scenario 1 corresponds to the Line 0601 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences" (https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
+    * This Scenario 1 corresponds to the [Line 0601 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
 
       * Scenario 2
         * Pre-conditions

--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -43,7 +43,8 @@ info:
     Note:
     * This Scenario 2 corresponds to the [Line 0607 in Section 4.4 of the CAMARA whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf).
 
-    ##How to choose specifiedDate by ASP (API consumer)
+    ## How to choose specifiedDate by ASP (API consumer)
+
     ASP should choose a date when the ASP established a trusted association between the user and the phone number, for example onboarding, phone number verification, or another validated point in the ASP's own trust process. A previous Number Recycling check that returned `false` may be used as an operational reference date, if this is consistent with the ASP's own trust model.
 
     However, a date that is trusted from the ASP perspective is not necessarily processable by every API provider. If `specifiedDate` is outside the API provider's supported/evaluable window and therefore cannot be processed as a valid reference date, the response should be `OUT_OF_RANGE` rather than a boolean result.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
The response table of Numer Recycling in Section 4.4 of the whitepaper should be referred since Sync26 release and onwards. In addition, a text in the API yaml file which is conflict with the whitepaper should be updated.

#### Which issue(s) this PR fixes:
Fixes #105 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
  - Update responses as they align with whitepaper
```

#### Additional documentation 
[a whitepaper "CAMARA APIs: Functional Differences"](https://camaraproject.org/wp-content/uploads/sites/12/2026/06/CAMARA-wp_api_diff_060126a.pdf)