### PR TITLE
Delete an unused schema Generic200

### DIFF
--- a/code/API_definitions/number-recycling.yaml
+++ b/code/API_definitions/number-recycling.yaml
@@ -180,16 +180,6 @@ components:
           description: |
             Set to true (Boolean, not string) when there has been a change in the subscriber associated with the specific phone number after “specifiedDate”.
   responses:
-    Generic200:
-      description: OK
-      headers:
-        x-correlator:
-          $ref: '../common/CAMARA_common.yaml#/components/headers/x-correlator'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CheckNumRecyclingInfo'
-
     Generic400:
       description: Problem with the client request
       headers:


### PR DESCRIPTION
#### What type of PR is this?
* cleanup

#### What this PR does / why we need it:
To delete an unused schema Generic200.

#### Which issue(s) this PR fixes:
Fixes #112

#### Special notes for reviewers:
I think it is good to include this PR in M3 release.
Could you review this PR as soon as possible?

#### Changelog input
```
 release-note
 - Delete the unused schema Generic200.
```

#### Additional documentation 
None